### PR TITLE
Move to a trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +36,5 @@ jobs:
 
       - run: "pnpm build"
 
-      - name: Publish to NPM
-        run: pnpm publish --access public --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to NPM (OIDC)
+        run: npm publish --access public --provenance --ignore-scripts


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the publish workflow to use OIDC with npm CLI for trusted publishing and adjusts permissions accordingly.
> 
> - **CI/CD (GitHub Actions)**
>   - **Publish Workflow** (`.github/workflows/publish.yml`):
>     - Switch from `pnpm publish` with `NODE_AUTH_TOKEN` to `npm publish` using OIDC (`--provenance`, `--ignore-scripts`).
>     - Add `permissions.contents: read` for the job.
>     - Remove token-based env; rely on OIDC for authentication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76d4d062ac45a2b1fe28fb6c320b4cea4d7f5076. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->